### PR TITLE
Update exercise 01-01-01 and solution to use most recent node Alpine

### DIFF
--- a/01-docker/01-docker/EXERCISE-01.md
+++ b/01-docker/01-docker/EXERCISE-01.md
@@ -57,7 +57,7 @@ EXPOSE 80
 
 Notes about the _Dockerfile_ (refer to the [Dockerfile reference](https://docs.docker.com/reference/builder/)) for more details):
 
-- `FROM` specifies the base image to build our image upon (_node:10.11.0-alpine_ contains the NodeJS runtime)
+- `FROM` specifies the base image to build our image upon (_node:15.4.0-alpine_ contains the NodeJS runtime)
 - `COPY` simply copies a file from the host file system to the image filesystem
 - `EXPOSE` identifies the network ports the container will listen on
 - `CMD` specifies the executable to run when a container is started from the image (we are using the _exec_ form)

--- a/01-docker/01-docker/solution/Dockerfile
+++ b/01-docker/01-docker/solution/Dockerfile
@@ -1,6 +1,10 @@
-FROM node:10.11.0-alpine
-RUN npm install express redis
+FROM node:15.4.0-alpine
+
 COPY files/ /files/
-COPY webui.js /
+COPY webui-dist.js /files/webui.js
+
+WORKDIR /files
+RUN npm install express redis
+
 CMD ["node", "webui.js"]
 EXPOSE 80

--- a/01-docker/01-docker/solution/Dockerfile
+++ b/01-docker/01-docker/solution/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:15.4.0-alpine
 
 COPY files/ /files/
-COPY webui-dist.js /files/webui.js
+COPY webui.js /files/webui.js
 
 WORKDIR /files
 RUN npm install express redis


### PR DESCRIPTION
Solution to this exercise is slightly different on the latest node from the existing solution.

Looks like a node/npm change means that we now need to be in the project directory before running `npm install`. Updating to match this as some people will likely choose the latest node alpine and then run into issues.